### PR TITLE
use revamped rng starting kernel 6.1

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="uvesafb"
-PACKAGE_VERSION="1.0.0"
+PACKAGE_VERSION="1.0.5"
 MAKE[0]="'make' BASEDIR=/usr/lib/modules/${kernelver} modules"
 CLEAN="'make' clean"
 BUILT_MODULE_LOCATION="src/"

--- a/src/uvesafb.c
+++ b/src/uvesafb.c
@@ -24,6 +24,14 @@
 #include <linux/slab.h>
 #include <video/edid.h>
 #include <video/uvesafb.h>
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+#define RANDOM_FUNC get_random_u32
+#else
+#define RANDOM_FUNC prandom_u32
+#endif
+	
 #ifdef CONFIG_X86
 #include <video/vga.h>
 #endif
@@ -320,7 +328,7 @@ static int uvesafb_exec(struct uvesafb_ktask *task)
 	memcpy(&m->id, &uvesafb_cn_id, sizeof(m->id));
 	m->seq = seq;
 	m->len = len;
-	m->ack = prandom_u32();
+	m->ack = RANDOM_FUNC();
 
 	/* uvesafb_task structure */
 	memcpy(m + 1, &task->t, sizeof(task->t));


### PR DESCRIPTION
The random number generator in Linux has been revamped to use new functions, and prandom_u32() was turned into a wrapper for the new function, get_random_u32(), in 5.19: torvalds/linux@d415077

This wrapper function was also removed in 6.1: torvalds/linux@de492c8

Also updating the version.